### PR TITLE
Project IRC comms are moving to Libera. Update docs.

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -11,7 +11,7 @@ We want your feedback, issues, patches, and involvement in the development of Po
 
 ## Slack and IRC
 
-The Podman developers often hang out on the #CRI-O channel in [Kubernetes Slack](https://slack.k8s.io/). Note that the devs are generally around during CEST and Eastern Time business hours, so be patient if you're in another time zone. There's also Podman users and developers on [IRC.Freenode.Net](https://webchat.freenode.net/) channel #podman.
+The Podman developers often hang out on the #CRI-O channel in [Kubernetes Slack](https://slack.k8s.io/). Note that the devs are generally around during CEST and Eastern Time business hours, so be patient if you're in another time zone. There's also Podman users and developers on [irc.libera.chat](https://web.libera.chat/#podman) channel #podman.
 
 ## Community Meetings
 


### PR DESCRIPTION
Confirmation cookie: libera-ieVeeGahbiaf1einguw1xav6bahquie

Signed-off-by: Ed Santiago <santiago@redhat.com>
